### PR TITLE
PyYAML - CVE-2017-18342

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,13 +6,13 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-certifi = {version="*"}
-chardet = {version="*"}
-idna = {version="*"}
-requests = {version="*"}
-urllib3 = {version="*"}
-xlwt = {version="*"}
-PyYAML = {version="*"}
+certifi = {version = "*"}
+chardet = {version = "*"}
+idna = {version = "*"}
+requests = {version = "*"}
+urllib3 = {version = "*"}
+xlwt = {version = "*"}
+PyYAML = {version = ">=4.2b"}
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "774bf188779b8dda912bc32722a07124c7b15760fcab19bcfd18482263280c68"
+            "sha256": "75a3095c9376c37fc4ee1958b79f9e5b1149859f633c10a8d450eb0b45a7c5dc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -42,20 +42,14 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
+                "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
+                "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
+                "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
+                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
             ],
             "index": "pypi",
-            "version": "==3.13"
+            "version": "==4.2b4"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
Using `{version = ">=4.2b1}` syntax, which breaks `pipenv upgrade`